### PR TITLE
display short description on experience card

### DIFF
--- a/src/lib/components/ExperienceCard/ExperienceCard.svelte
+++ b/src/lib/components/ExperienceCard/ExperienceCard.svelte
@@ -49,7 +49,7 @@
 				</ChipIcon>
 			</div>
 			<div class="text-[var(--accent-text)] text-[0.9em] font-200">{period}</div>
-			<div class="experience-description">{experience.description}</div>
+			<div class="experience-description">{experience.shortDescription}</div>
 			<div class="flex flex-row flex-wrap mt-5">
 				{#each experience.skills as skill}
 					<ChipIcon


### PR DESCRIPTION
I think there was a typo in here. shouldn't this be short description instead?